### PR TITLE
chore: drop redundant main field

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "typescript"
   ],
   "license": "MIT",
-  "main": "dist/index.js",
   "name": "@echecs/elo",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- removed redundant `"main": "dist/index.js"` from `package.json` (already covered by `"exports"`)