### PR TITLE
chore: normalize types field path

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,6 @@
     "test:watch": "pnpm run test --watch"
   },
   "type": "module",
-  "types": "dist/index.d.ts",
+  "types": "./dist/index.d.ts",
   "version": "4.0.2"
 }


### PR DESCRIPTION
uses relative ./dist/index.d.ts path consistently across all packages