### PR TITLE
chore: bump minimum node to 22

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "vitest": "^4.1.0"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
node 20 reached EOL on april 30 2026 — 22 is the oldest maintained LTS