### PR TITLE
chore: update homepage to echecs.dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "README.md",
     "CHANGELOG.md"
   ],
-  "homepage": "https://github.com/echecsjs/elo#readme",
+  "homepage": "https://elo.echecs.dev",
   "keywords": [
     "chess",
     "elo",


### PR DESCRIPTION
points homepage to the docs site instead of the github repo