### PR TITLE
chore: add dependabot cooldown for supply chain safety

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: daily
       time: '13:00'
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 2
     commit-message:
       prefix: 'chore'
       include: 'scope'


### PR DESCRIPTION
adds `cooldown.default-days: 2` to dependabot config. dependabot will wait 2 days before opening PRs for newly-published packages, aligning with pnpm 11's `minimumReleaseAge` default (1 day) with margin.